### PR TITLE
Modify correct_syntax to use closest match instead of hard coding errors

### DIFF
--- a/Gherkin2Fibery.py
+++ b/Gherkin2Fibery.py
@@ -2,7 +2,7 @@ import csv
 import sys
 import os
 from collections import OrderedDict
-
+import difflib
 
 def parse_feature_file(file_path):
     with open(file_path, 'r') as file:
@@ -127,14 +127,14 @@ def check_formatting(file_path):
 
 
 def correct_syntax(lines):
+    valid_keywords = ['Feature:', 'Scenario:', 'Scenario Outline:', 'Developer Task:', 'Given', 'When', 'Then', 'And', 'Examples', '|']
     corrected_lines = []
     for line in lines:
-        if line.startswith('Sceanario:'):
-            corrected_lines.append(line.replace('Sceanario:', 'Scenario:'))
-        elif line.startswith('Giben'):
-            corrected_lines.append(line.replace('Giben', 'Given'))
-        elif line.startswith('1Scenario:'):
-            corrected_lines.append(line.replace('1Scenario:', 'Scenario:'))
+        line_stripped = line.lstrip()
+        closest_matches = difflib.get_close_matches(line_stripped.split()[0], valid_keywords, n=1, cutoff=0.8)
+        if closest_matches:
+            corrected_line = line.replace(line_stripped.split()[0], closest_matches[0])
+            corrected_lines.append(corrected_line)
         else:
             corrected_lines.append(line)
     return corrected_lines

--- a/TestFile.feature
+++ b/TestFile.feature
@@ -102,3 +102,18 @@ Scenario: scenario 15
 Given step 46
 When step 47
 Then step 48
+
+Scenarios: scenario 16
+Givn step 49
+When step 50
+Then step 51
+
+scenario: scenario 17
+Givn step 52
+When step 53
+Then step 54
+
+Scenario: scenario 18
+Given step 55
+Wen step 56
+The step 57


### PR DESCRIPTION
Modify `correct_syntax(lines)` function to use closest match for syntax errors instead of hard-coded replacements.

* **Gherkin2Fibery.py**
  - Import `difflib` module.
  - Add a list of valid Gherkin keywords.
  - Use `difflib.get_close_matches` to find closest matches for syntax errors.
  - Replace hard-coded replacements with dynamic replacements using closest matches.

* **TestFile.feature**
  - Add additional syntax errors to test the new `correct_syntax` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FF2F?shareId=XXXX-XXXX-XXXX-XXXX).