### PR TITLE
Add scenario outline check

### DIFF
--- a/TestFile.feature
+++ b/TestFile.feature
@@ -56,6 +56,24 @@ Given step 21
 When step 22
 Then step 23
 
+Scenario Outline: Valid scenario outline with three example lines: scenario 9
+Given step 24 <column 1>
+When step 25
+Then step 26
+Examples:
+| column 1 |
+| value 1  |
+| value 2  |
+
+
+Scenario Outline: Invalid scenario outline with less than three example lines: scenario 10
+Given step 27 <column 1>
+When step 28
+Then step 29
+Examples:
+| column 1 |
+| value 1  |
+
 Feature: feature 2
 
 Scenario: scenario 9

--- a/parser.py
+++ b/parser.py
@@ -29,6 +29,8 @@ class Parser:
                   line.startswith('Developer Task:')):
                 current_scenario = line.strip()
                 features = self.process_feature_line(features, current_feature, current_scenario, line)
+                if line.startswith('Scenario Outline:'):
+                    self.check_scenario_outline(data, line_number)
             elif any(line.startswith(keyword) for keyword in ['Given', 'When', 'Then', 'And', 'Examples', '|']):
                 features = self.process_scenario_line(features, current_feature, current_scenario, line)
             elif line:
@@ -49,3 +51,18 @@ class Parser:
         if current_feature and current_scenario:
             features.append([current_feature, current_scenario, line])
         return features
+
+    def check_scenario_outline(self, data, line_number):
+        examples_found = False
+        example_lines = 0
+        for line in data[line_number:]:
+            if line.startswith('Examples:'):
+                examples_found = True
+            elif examples_found and line.startswith('|'):
+                example_lines += 1
+            elif examples_found and not line.startswith('|'):
+                break
+
+        if not examples_found or example_lines < 3:
+            print(f"Error: 'Scenario Outline:' at line {line_number} is not followed by 'Examples:' and at least three lines starting with '|'")
+            exit(1)


### PR DESCRIPTION
Add a check to ensure 'Scenario Outline:' is followed by 'Examples:' and at least three lines starting with '|'.

* **parser.py**
  - Add `check_scenario_outline` method to validate 'Scenario Outline:' format.
  - Call `check_scenario_outline` in `extract_features` method after processing 'Scenario Outline:'.

* **TestFile.feature**
  - Add a valid example of 'Scenario Outline:' with 'Examples:' and at least three lines starting with '|'.
  - Add an invalid example of 'Scenario Outline:' without 'Examples:' or with less than three lines starting with '|'.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FF2F/pull/6?shareId=edb5d967-751c-4565-a99c-d7af3167b431).