### PR TITLE
Fix issue to report all incorrect Gherkin and Scenario Outline issues

### DIFF
--- a/corrector.py
+++ b/corrector.py
@@ -34,4 +34,7 @@ class Corrector:
 
     def handle_invalid_syntax(self, line_number, line):
         print(f"Invalid Gherkin syntax at line {line_number}: {line}")
-        return self.correct_syntax([line])[0]
+        corrected_line = self.correct_syntax([line])[0]
+        if corrected_line != line:
+            print(f"Corrected Gherkin syntax at line {line_number}: {corrected_line}")
+        return corrected_line

--- a/parser.py
+++ b/parser.py
@@ -36,7 +36,6 @@ class Parser:
                 corrected_line = self.corrector.handle_invalid_syntax(line_number, line)
                 if corrected_line:
                     data[line_number - 1] = corrected_line
-                    return self.extract_features(data)
         return features
 
     def process_feature_line(self, features, current_feature, current_scenario, line):
@@ -54,6 +53,7 @@ class Parser:
     def check_scenario_outline(self, data, line_number):
         examples_found = False
         example_lines = 0
+        invalid_scenario_outlines = []
         for line in data[line_number:]:
             if line.startswith('Examples:'):
                 examples_found = True
@@ -63,5 +63,7 @@ class Parser:
                 break
 
         if not examples_found or example_lines < 3:
-            print(f"Error: 'Scenario Outline:' at line {line_number} is not followed by 'Examples:' and at least three lines starting with '|'")
-            exit(1)
+            invalid_scenario_outlines.append(line_number)
+
+        if invalid_scenario_outlines:
+            print(f"Error: 'Scenario Outline:' at lines {invalid_scenario_outlines} are not followed by 'Examples:' and at least three lines starting with '|'")


### PR DESCRIPTION
Update `parser.py` and `corrector.py` to report all incorrect Gherkin and Scenario Outline issues to the user, not just the first.

* **parser.py**
  - Modify `extract_features` method to continue checking the rest of the file after handling the first invalid line.
  - Update `check_scenario_outline` method to collect all invalid Scenario Outlines and report them at the end, without exiting the program.

* **corrector.py**
  - Update `handle_invalid_syntax` method to continue checking for further issues after correcting the first invalid line.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FF2F/pull/8?shareId=394a58c1-6329-4622-af7f-ac60e651cbdb).