### PR TITLE
Fix error in Parser class by initializing Corrector class

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -1,11 +1,13 @@
 import difflib
 from validator import Validator
 from error_handler import ErrorHandler
+from corrector import Corrector
 
 class Parser:
     def __init__(self, keywords, error_handler):
         self.validator = Validator(keywords, error_handler)
         self.error_handler = error_handler
+        self.corrector = Corrector(keywords, error_handler)
 
     def parse_feature_file(self, file_content):
         lines = file_content.splitlines()


### PR DESCRIPTION
Initialize the `Corrector` class in the `Parser` class.

* Import the `Corrector` class from `corrector.py`.
* Initialize the `Corrector` class in the `Parser` class constructor.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FF2F/pull/16?shareId=f6fd2abd-a4bb-4a50-83fe-2c837cf9b912).