### PR TITLE
Remove debug print statements from code

### DIFF
--- a/corrector.py
+++ b/corrector.py
@@ -11,7 +11,6 @@ class Corrector:
     def correct_syntax(self, lines):
         corrected_lines = []
         for line_number, line in enumerate(lines, start=1):
-            print(f"Correcting line {line_number}: {line.strip()}")  # Debug statement
             line_stripped = line.strip()
             if not line_stripped:
                 corrected_lines.append(line)
@@ -28,10 +27,8 @@ class Corrector:
                 # If no valid keyword is found, attempt to correct the first word
                 first_word = line_stripped.split()[0]
                 closest_matches = difflib.get_close_matches(first_word, self.valid_keywords, n=1, cutoff=0.8)
-                print(f"Closest matches for '{first_word}': {closest_matches}")  # Debug statement
                 if closest_matches:
                     corrected_line = closest_matches[0] + line_stripped[len(first_word):]
-                    print(f"Corrected line: {corrected_line}")  # Debug statement
                     corrected_lines.append(corrected_line)
                 else:
                     corrected_lines.append(line)
@@ -40,7 +37,6 @@ class Corrector:
         return corrected_lines
 
     def handle_invalid_syntax(self, line_number, line):
-        print(f"Handling invalid syntax at line {line_number}: {line.strip()}")  # Debug statement
         self.error_handler.add_error(line_number, 'error', f"Invalid Gherkin syntax: {line}")
         corrected_line = self.correct_syntax([line])[0]
         if corrected_line != line:

--- a/csv_writer.py
+++ b/csv_writer.py
@@ -6,7 +6,6 @@ class CSVWriter:
         pass
 
     def write_to_csv(self, data, output_file):
-        print(f"Writing to CSV file: {output_file}")  # Debug statement
         with open(output_file, 'w', newline='') as file:
             writer = csv.writer(file)
             writer.writerow(['Scenarios'])
@@ -23,12 +22,10 @@ class CSVWriter:
             if scenario and scenario not in seen:
                 scenarios.append(scenario)
                 seen[scenario] = None
-        print(f"Extracted scenarios: {scenarios}")  # Debug statement
         return scenarios
 
     def write_scenarios(self, writer, scenarios):
         for scenario in scenarios:
-            print(f"Writing scenario: {scenario}")  # Debug statement
             writer.writerow([scenario])
 
     def write_features_and_steps(self, writer, data):
@@ -46,7 +43,6 @@ class CSVWriter:
             else:
                 last_scenario = scenario
 
-            print(f"Writing feature: {feature}, scenario: {scenario}, step: {step}")  # Debug statement
             writer.writerow([feature, scenario, step])
 
             if i + 1 < len(data) and data[i + 1][1] != last_scenario:

--- a/parser.py
+++ b/parser.py
@@ -11,7 +11,6 @@ class Parser:
 
     def parse_feature_file(self, file_content):
         lines = file_content.splitlines()
-        print(f"Parsing {len(lines)} lines")  # Debug statement
 
         self.validator.validate_syntax(lines)
         features = self.extract_features(lines)
@@ -32,7 +31,6 @@ class Parser:
                   line.startswith('Scenario Outline:') or
                   line.startswith('Developer Task:')):
                 current_scenario = line.strip()
-                print(f"Processing feature: {current_feature}, scenario: {current_scenario}")  # Debug statement
                 features = self.process_feature_line(features, current_feature, current_scenario, line)
                 if line.startswith('Scenario Outline:'):
                     self.check_scenario_outline(data, line_number)
@@ -44,7 +42,6 @@ class Parser:
                     # If the line was corrected, reprocess it as a new line
                     if corrected_line.startswith('Scenario:') or corrected_line.startswith('Scenario Outline:') or corrected_line.startswith('Developer Task:'):
                         current_scenario = corrected_line.strip()
-                        print(f"Processing corrected feature: {current_feature}, scenario: {current_scenario}")  # Debug statement
                         features = self.process_feature_line(features, current_feature, current_scenario, corrected_line)
                         if corrected_line.startswith('Scenario Outline:'):
                             self.check_scenario_outline(data, line_number)
@@ -62,13 +59,11 @@ class Parser:
         if current_feature and not any(f[0] == current_feature for f in features):
             features.append([current_feature, '', ''])
         if current_feature and current_scenario:
-            print(f"Adding feature: {current_feature}, scenario: {current_scenario}")  # Debug statement
             features.append([current_feature, current_scenario, ''])
         return features
 
     def process_scenario_line(self, features, current_feature, current_scenario, line):
         if current_feature and current_scenario:
-            print(f"Adding feature: {current_feature}, scenario: {current_scenario}, step: {line}")  # Debug statement
             features.append([current_feature, current_scenario, line])
         return features
 
@@ -89,5 +84,4 @@ class Parser:
 
         if invalid_scenario_outlines:
             for invalid_line in invalid_scenario_outlines:
-                print(f"Invalid scenario outline at line {invalid_line}: {data[invalid_line - 1]}")  # Debug statement
                 self.error_handler.add_error(invalid_line, 'error', "'Scenario Outline:' is not followed by 'Examples:' and at least three lines starting with '|'")

--- a/validator.py
+++ b/validator.py
@@ -7,7 +7,6 @@ class Validator:
 
     def validate_syntax(self, lines):
         for line_number, line in enumerate(lines, start=1):
-            print(f"Validating line {line_number}: {line.strip()}")  # Debug statement
             line_stripped = line.strip()
             if not line_stripped:
                 continue
@@ -21,5 +20,4 @@ class Validator:
 
             if keyword is None:
                 # If no valid keyword is found, report an error
-                print(f"Invalid Gherkin syntax found at line {line_number}: {line}")  # Debug statement
                 self.error_handler.add_error(line_number, 'error', f"Invalid Gherkin syntax: {line}")


### PR DESCRIPTION
Remove debug print statements from `corrector.py`, `csv_writer.py`, `parser.py`, and `validator.py`.

* **corrector.py**: Remove debug print statements for correcting lines, closest matches, corrected lines, and handling invalid syntax.
* **csv_writer.py**: Remove debug print statements for writing to CSV, extracting scenarios, writing scenarios, and writing features and steps.
* **parser.py**: Remove debug print statements for parsing lines, processing features and scenarios, adding features and scenarios.
* **validator.py**: Remove debug print statements for validating lines and reporting invalid Gherkin syntax.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FF2F/pull/31?shareId=59c1a2ff-c3d7-4a44-b435-2c88de059449).