### PR TITLE
Place created CSVs in GeneratedCSV folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyo
 .DS_Store
 *.log
+GeneratedCSV/

--- a/FF2F.py
+++ b/FF2F.py
@@ -12,12 +12,15 @@ def main():
 
     feature_file_path = sys.argv[1]
     base_name = os.path.splitext(os.path.basename(feature_file_path))[0]
-    output_csv_path = f"{base_name}.csv"
+    output_csv_path = os.path.join("GeneratedCSV", f"{base_name}.csv")
+
+    if not os.path.exists("GeneratedCSV"):
+        os.makedirs("GeneratedCSV")
 
     if os.path.exists(output_csv_path):
         counter = 1
         while os.path.exists(output_csv_path):
-            output_csv_path = f"{base_name}_{counter}.csv"
+            output_csv_path = os.path.join("GeneratedCSV", f"{base_name}_{counter}.csv")
             counter += 1
 
     with open(feature_file_path, 'r') as file:


### PR DESCRIPTION
Place created CSVs in a new folder called 'GeneratedCSV' and add this folder to .gitignore.

* **FF2F.py**
  - Import `os` and `sys` modules.
  - Update `output_csv_path` to include `GeneratedCSV` folder.
  - Add code to create `GeneratedCSV` folder if it does not exist.
  - Update code to write CSV files to the `GeneratedCSV` folder.

* **.gitignore**
  - Add `GeneratedCSV/` to the list of ignored files and folders.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FF2F/pull/36?shareId=2a6e19f9-258b-482f-bb76-824533441d13).