### PR TITLE
Format error output in columns for easier reading

### DIFF
--- a/corrector.py
+++ b/corrector.py
@@ -45,8 +45,8 @@ class Corrector:
         return corrected_lines
 
     def handle_invalid_syntax(self, line_number, line):
-        self.error_handler.add_error(line_number, 'error', f"Invalid Gherkin syntax: {line}")
+        self.error_handler.add_error(line_number, 'warning', f"Invalid Gherkin syntax: {line}")
         corrected_line = self.correct_syntax([line])[0]
         if corrected_line != line:
-            self.error_handler.add_error(line_number, 'warning', f"Corrected Gherkin syntax: {corrected_line}")
+            self.error_handler.add_error(line_number, 'update', f"Corrected Gherkin syntax: {corrected_line}")
         return corrected_line

--- a/error_handler.py
+++ b/error_handler.py
@@ -14,4 +14,4 @@ class ErrorHandler:
 
     def print_errors(self):
         for error in self.errors:
-            print(f"[{error['severity'].upper()}] Line {error['line_number']}: {error['message']}")
+            print(f"[{error['severity'].upper():<8}] Line {error['line_number']:<4}: {error['message']}")


### PR DESCRIPTION
Update the `print_errors` method in `error_handler.py` and the `handle_invalid_syntax` method in `corrector.py` to format error messages with fixed-width columns.

* **error_handler.py**
  - Update the `print_errors` method to print errors with aligned columns for severity, line number, and message.

* **corrector.py**
  - Update the `handle_invalid_syntax` method to use the updated `add_error` method to add errors with the new formatting.
  - Change the severity level of the error message for invalid Gherkin syntax to 'warning'.
  - Change the severity level of the corrected Gherkin syntax message to 'update'.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FF2F/pull/38?shareId=d7a02163-aa1d-4120-ab9a-a82721d84a6a).