### PR TITLE
Add input validation for feature files

### DIFF
--- a/FF2F.py
+++ b/FF2F.py
@@ -4,6 +4,7 @@ from parser import Parser
 from csv_writer import CSVWriter
 from config import Config
 from error_handler import ErrorHandler
+import input_validator
 
 def main():
     if len(sys.argv) != 2:
@@ -22,6 +23,16 @@ def main():
         while os.path.exists(output_csv_path):
             output_csv_path = os.path.join("GeneratedCSV", f"{base_name}_{counter}.csv")
             counter += 1
+
+    is_readable, message = input_validator.is_file_readable(feature_file_path)
+    if not is_readable:
+        print(message)
+        sys.exit(1)
+
+    is_valid, message = input_validator.is_valid_gherkin_file(feature_file_path)
+    if not is_valid:
+        print(message)
+        sys.exit(1)
 
     with open(feature_file_path, 'r') as file:
         file_content = file.read()

--- a/input_validator.py
+++ b/input_validator.py
@@ -1,0 +1,25 @@
+import os
+from config import Config
+
+def is_file_readable(file_path):
+    return os.path.isfile(file_path) and os.access(file_path, os.R_OK)
+
+def is_valid_gherkin_file(file_path):
+    if not is_file_readable(file_path):
+        return False, "File does not exist or is not readable."
+
+    with open(file_path, 'r') as file:
+        first_line = file.readline().strip()
+        if not first_line.startswith("Feature:"):
+            return False, "File is not a valid Gherkin file."
+
+    config = Config()
+    keywords = config.get_keywords()
+
+    with open(file_path, 'r') as file:
+        for line in file:
+            line = line.strip()
+            if line and not any(line.startswith(keyword) for keyword in keywords):
+                return False, "File contains invalid Gherkin syntax."
+
+    return True, "File is a valid Gherkin file."


### PR DESCRIPTION
Add input validation for feature file in `FF2F.py`.

* **input_validator.py**: 
  - Add `is_file_readable` function to check if a file exists and is readable.
  - Add `is_valid_gherkin_file` function to check if a file is a valid Gherkin or txt file.
  - Use `Config` class to get the list of Gherkin keywords for validation.

* **FF2F.py**:
  - Import `input_validator` module.
  - Add check for file readability using `input_validator.is_file_readable`.
  - Add validation for Gherkin file format using `input_validator.is_valid_gherkin_file`.
  - Print error message and exit if the file is not valid.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FF2F/pull/41?shareId=a5a2743c-a400-47e0-9fc3-60c753886f39).