### PR TITLE
Add validation for Gherkin syntax percentage

### DIFF
--- a/FF2F.py
+++ b/FF2F.py
@@ -31,6 +31,7 @@ def main():
     is_valid, validation_error = validator.validate()
     if not is_valid:
         print(f"Validation Error: {validation_error}")
+        sys.exit(1)
 
     config = Config()
     keywords = config.get_keywords()

--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ The `Validator` class is responsible for validating the input feature file befor
 - UTF-8 encoding
 - Valid Gherkin format
 - Basic structure (presence of `Feature:` and `Scenario:` keywords)
+- Gherkin syntax percentage (at least 80%)
 
 The `Validator` class provides the following methods:
 
 - `validate_encoding()`: Checks if the file is UTF-8 encoded.
 - `validate_format()`: Checks if the file has a valid Gherkin format.
 - `validate_structure()`: Checks if the file contains the required `Feature:` and `Scenario:` keywords.
+- `validate_gherkin_syntax_percentage()`: Checks if the percentage of Gherkin syntax is at least 80%.
 - `validate()`: Calls all validation methods and returns the results.
 
 ## Usage

--- a/validator.py
+++ b/validator.py
@@ -23,6 +23,15 @@ class Validator:
             return False, "File does not contain required 'Feature:' or 'Scenario:' keywords."
         return True, None
 
+    def validate_gherkin_syntax_percentage(self):
+        lines = self.file_content.splitlines()
+        total_lines = len(lines)
+        gherkin_lines = sum(1 for line in lines if any(line.strip().startswith(keyword) for keyword in ['Feature:', 'Scenario:', 'Scenario Outline:', 'Developer Task:', 'Given', 'When', 'Then', 'And', 'Examples:', '|']))
+        gherkin_percentage = (gherkin_lines / total_lines) * 100
+        if gherkin_percentage < 80:
+            return False, f"Gherkin syntax percentage is less than 80%: {gherkin_percentage:.2f}%"
+        return True, None
+
     def validate(self):
         encoding_valid, encoding_error = self.validate_encoding()
         if not encoding_valid:
@@ -35,5 +44,9 @@ class Validator:
         structure_valid, structure_error = self.validate_structure()
         if not structure_valid:
             return False, structure_error
+
+        gherkin_valid, gherkin_error = self.validate_gherkin_syntax_percentage()
+        if not gherkin_valid:
+            return False, gherkin_error
 
         return True, None


### PR DESCRIPTION
Add validation for the percentage of Gherkin syntax found; if the percentage is less than 80%, do not process the file and do not create a CSV.

* **validator.py**
  - Add `validate_gherkin_syntax_percentage` method to check if the percentage of Gherkin syntax is at least 80%.
  - Update `validate` method to call `validate_gherkin_syntax_percentage` and return its result.

* **FF2F.py**
  - Update `main` function to call `validate_gherkin_syntax_percentage` before processing the file.
  - Print validation error and exit if Gherkin syntax percentage is less than 80%.

* **README.md**
  - Update documentation to include information about the new validation for Gherkin syntax percentage.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zeegar/FF2F/pull/45?shareId=9a956945-0f2c-472d-912d-5df6c37227ec).